### PR TITLE
Can now save degree distribution in a CSV file using --degree arg

### DIFF
--- a/StochasticBlockPartition/code/python/graph.py
+++ b/StochasticBlockPartition/code/python/graph.py
@@ -5,6 +5,7 @@ import os
 import sys
 from typing import List, Optional, Tuple, Dict
 import argparse
+import csv
 
 import numpy as np
 import pandas as pd
@@ -77,6 +78,8 @@ class Graph():
                 graph.update(_load_graph(input_filename, load_true_partition=False, part_num=part, graph=graph))
         else:
             graph = _load_graph(input_filename, load_true_partition=True)
+            if args.degrees:
+                _save_degree_distribution(args, graph.out_neighbors, graph.in_neighbors)
         return graph
     # End of load()
 
@@ -213,3 +216,37 @@ def _load_graph(input_filename: str, load_true_partition: bool, part_num: Option
     else:
         return Graph(out_neighbors, in_neighbors, N, E)
 # End of load_graph()
+
+
+def _save_degree_distribution(args: argparse.Namespace, out_neighbors: List[np.ndarray],
+    in_neighbors: List[np.ndarray]):
+    """Saves the in and out degrees of all vertices in the graph.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        the command-line arguments provided
+    out_neighbors : List[np.ndarray]
+        the outgoing edges from each node
+    in_neighbors : List[np.ndarray]
+        the incoming edges to each node
+    """
+    write_header = False
+    if not os.path.isfile(args.csv + ".csv"):
+        directory = os.path.dirname(args.csv + ".csv")
+        if directory not in [".", ""]:
+            os.makedirs(directory, exist_ok=True)
+        write_header = True
+    num_vertices = len(out_neighbors)
+    out_degrees = [len(neighbors) for neighbors in out_neighbors]
+    in_degrees = [len(neighbors) for neighbors in in_neighbors]
+    with open(args.csv + ".csv", "a") as details_file:
+        writer = csv.writer(details_file)
+        if write_header:
+            writer.writerow(["Num Vertices", "In/Out", "Degree"])
+        for degree in out_degrees:
+            writer.writerow([num_vertices, "Out", degree])
+        for degree in in_degrees:
+            writer.writerow([num_vertices, "In", degree])
+    exit()
+# End of _save_degree_distribution()

--- a/StochasticBlockPartition/code/python/partition_baseline_main.py
+++ b/StochasticBlockPartition/code/python/partition_baseline_main.py
@@ -70,6 +70,7 @@ def parse_arguments():
                         choices=["uniform_random", "random_walk", "random_jump", "degree_weighted",
                                  "random_node_neighbor", "forest_fire", "none"],
                         help="""Sampling algorithm to use. Default = none""")
+    parser.add_argument("--degrees", action="store_true", help="Save vertex degrees and exit.")
     args = parser.parse_args()
     return args
 # End of parse_arguments()


### PR DESCRIPTION
Added argument 'degree'. If True, upon creating the Graph object, the in and out-degrees will be saved, and the script exits.

The CSV file is specified using the 'csv' argument.

Example:

```python partition_baseline_main.py -n 50000 --degree --csv eval/degrees_50000_vertices```